### PR TITLE
extensions regarding datadog tags

### DIFF
--- a/charts/dvpe-deployment-gloo/CHANGELOG.md
+++ b/charts/dvpe-deployment-gloo/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2021-03-??
+
 ### Added
 
 * Added tags `env`, `service` and `version` for DataDog according to [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging?tab=kubernetes).
@@ -99,4 +101,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.2]: https://github.com/DVPE-cloud/dvpe-helm/tree/dvpe-deployment-gloo-0.0.2/charts/dvpe-deployment-gloo
 [1.0.0]: https://github.com/DVPE-cloud/dvpe-helm/tree/dvpe-deployment-gloo-1.0.0/charts/dvpe-deployment-gloo
 [1.1.0]: https://github.com/DVPE-cloud/dvpe-helm/tree/dvpe-deployment-gloo-1.1.0/charts/dvpe-deployment-gloo
+[1.3.0]: https://github.com/DVPE-cloud/dvpe-helm/tree/dvpe-deployment-gloo-1.3.0/charts/dvpe-deployment-gloo
+[1.3.1]: https://github.com/DVPE-cloud/dvpe-helm/tree/dvpe-deployment-gloo-1.3.1/charts/dvpe-deployment-gloo
 

--- a/charts/dvpe-deployment-gloo/CHANGELOG.md
+++ b/charts/dvpe-deployment-gloo/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2021-02-??
+### Added
+
+* Added tags `env`, `service` and `version` for DataDog according to [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging?tab=kubernetes).
+
+## [1.3.0] - 2021-02-19
 
 ### Breaking Changes
 

--- a/charts/dvpe-deployment-gloo/Chart.yaml
+++ b/charts/dvpe-deployment-gloo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Helm chart for installing microservices as gloo enabled VirtualService definitions.
 name: dvpe-deployment-gloo
-version: 1.3.0
+version: 1.3.1
 home: https://github.com/dvpe-cloud/dvpe-helm
 keywords:
   - dvpe-helm

--- a/charts/dvpe-deployment-gloo/README.md
+++ b/charts/dvpe-deployment-gloo/README.md
@@ -1,6 +1,6 @@
 # dvpe-deployment-gloo
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square)
 
 Helm chart for installing microservices as gloo enabled VirtualService definitions.
 
@@ -191,8 +191,10 @@ The following table lists the configurable parameters of the chart and its defau
 | autoscaling.metrics.resource.cpu.targetAverageUtilization | int | `80` | Defines cpu utilization threshold in % for the HPA to scale up new pods. |
 | autoscaling.minReplicas | int | `1` | Defines `minReplicas` of Pods scaled automatically by Horizontal Pod Autoscaler (HPA). |
 | datadog.enabled | bool | `true` | When set to true Datadog is enabled and all logs, metrics and traces will be sent to Datadog. |
+| datadog.env | string | `"none"` | Label in Datadog for the target environment - e.g. test, int, prod or an abbreviated k8s cluster name. |
 | datadog.source | string | `nil` | Defines the source which creates log outputs. Source defines the log format and triggers Datadog parser pipelines |
 | datadog.team | string | `nil` | Label in Datadog for the responsible team |
+| datadog.version | string | `nil` | Label in Datadog for the service version. If undefined, the value of `deployment.spec.image.tag` is used. This value should not be set by ordinary deployments. It is intended for special cases (e.g. CI triggered deployments). |
 | deployment.podAnnotations | object | `{}` | Object of additional `podAnnotations`. |
 | deployment.spec.containers.readinessProbe.failureThreshold | int | `3` | Number of times to retry the probe before giving up. |
 | deployment.spec.containers.readinessProbe.httpGet.path | string | `"/"` | Service's http path on which to execute a readinessProbe |

--- a/charts/dvpe-deployment-gloo/templates/deployment.yaml
+++ b/charts/dvpe-deployment-gloo/templates/deployment.yaml
@@ -8,6 +8,12 @@ kind: Deployment
 metadata:
   name: {{ $serviceName }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- if .Values.datadog.enabled }}
+    tags.datadoghq.com/env: {{ .Values.datadog.env }}
+    tags.datadoghq.com/service: {{ $serviceName }}
+    tags.datadoghq.com/version: {{ if .Values.datadog.version }}{{- .Values.datadog.version }}{{- else }}{{- .Values.deployment.spec.image.tag }}{{- end }}
+    {{- end }}
 spec:
   replicas: {{ .Values.deployment.spec.replicas }}
   selector:
@@ -17,6 +23,11 @@ spec:
     metadata:
       labels:
         app: {{ $serviceName }}
+        {{- if .Values.datadog.enabled }}
+        tags.datadoghq.com/env: {{ .Values.datadog.env }}
+        tags.datadoghq.com/service: {{ $serviceName }}
+        tags.datadoghq.com/version: {{ if .Values.datadog.version }}{{- .Values.datadog.version }}{{- else }}{{- .Values.deployment.spec.image.tag }}{{- end }}
+        {{- end }}
       annotations:
         {{- if .Values.datadog.enabled }}
         ad.datadoghq.com/{{ $serviceName }}.check_names: '["{{ $serviceName }}"]'
@@ -48,8 +59,18 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: "DD_SERVICE_NAME"
-            value: {{ $serviceName }}
+          - name: DD_ENV
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tags.datadoghq.com/env']
+          - name: DD_SERVICE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tags.datadoghq.com/service']
+          - name: DD_VERSION
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['tags.datadoghq.com/version']
           {{- end}}
           {{- if .Values.additionalparameters.configMapApplied }}
           {{- range $key, $value := .Values.additionalparameters.config }}

--- a/charts/dvpe-deployment-gloo/templates/deployment.yaml
+++ b/charts/dvpe-deployment-gloo/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- if .Values.datadog.enabled }}
     tags.datadoghq.com/env: {{ .Values.datadog.env }}
     tags.datadoghq.com/service: {{ $serviceName }}
-    tags.datadoghq.com/version: {{ if .Values.datadog.version }}{{- .Values.datadog.version }}{{- else }}{{- .Values.deployment.spec.image.tag }}{{- end }}
+    tags.datadoghq.com/version: {{ default .Values.deployment.spec.image.tag .Values.datadog.version }}
     {{- end }}
 spec:
   replicas: {{ .Values.deployment.spec.replicas }}
@@ -26,7 +26,7 @@ spec:
         {{- if .Values.datadog.enabled }}
         tags.datadoghq.com/env: {{ .Values.datadog.env }}
         tags.datadoghq.com/service: {{ $serviceName }}
-        tags.datadoghq.com/version: {{ if .Values.datadog.version }}{{- .Values.datadog.version }}{{- else }}{{- .Values.deployment.spec.image.tag }}{{- end }}
+        tags.datadoghq.com/version: {{ default .Values.deployment.spec.image.tag .Values.datadog.version }}
         {{- end }}
       annotations:
         {{- if .Values.datadog.enabled }}

--- a/charts/dvpe-deployment-gloo/values.yaml
+++ b/charts/dvpe-deployment-gloo/values.yaml
@@ -246,6 +246,11 @@ datadog:
   source:
   # datadog.team -- Label in Datadog for the responsible team
   team:
+  # datadog.env -- Label in Datadog for the target environment - e.g. test, int, prod or an abbreviated k8s cluster name.
+  env: none
+  # datadog.version -- Label in Datadog for the service version. If undefined, the value of `deployment.spec.image.tag` is used.
+  # This value should not be set by ordinary deployments. It is intended for special cases (e.g. CI triggered deployments).
+  version:
 
 # -------------------------------------#
 # Istio value section                  #


### PR DESCRIPTION
Extended `dvpe-deployment-gloo/templates/deployment.yaml` by adding tags `env`, `service` and `version` for DataDog according to https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging. 