### PR TITLE
allow subdomain within CORS configuration of VirtualService

### DIFF
--- a/charts/dvpe-deployment-gloo/CHANGELOG.md
+++ b/charts/dvpe-deployment-gloo/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2021-??-??
+
 ### Added
 
 * Extended CORS configuration support by adding  `gloo.virtualservice.spec.virtualHost.cors.allowSubdomain` value.

--- a/charts/dvpe-deployment-gloo/CHANGELOG.md
+++ b/charts/dvpe-deployment-gloo/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2021-02-??
+### Added
+
+* Extended CORS configuration support by adding  `gloo.virtualservice.spec.virtualHost.cors.allowSubdomain` value.
+
+## [1.3.0] - 2021-02-19
 
 ### Breaking Changes
 

--- a/charts/dvpe-deployment-gloo/Chart.yaml
+++ b/charts/dvpe-deployment-gloo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Helm chart for installing microservices as gloo enabled VirtualService definitions.
 name: dvpe-deployment-gloo
-version: 1.3.1
+version: 1.3.2
 home: https://github.com/dvpe-cloud/dvpe-helm
 keywords:
   - dvpe-helm

--- a/charts/dvpe-deployment-gloo/Chart.yaml
+++ b/charts/dvpe-deployment-gloo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: Helm chart for installing microservices as gloo enabled VirtualService definitions.
 name: dvpe-deployment-gloo
-version: 1.3.0
+version: 1.3.1
 home: https://github.com/dvpe-cloud/dvpe-helm
 keywords:
   - dvpe-helm

--- a/charts/dvpe-deployment-gloo/README.md
+++ b/charts/dvpe-deployment-gloo/README.md
@@ -1,6 +1,6 @@
 # dvpe-deployment-gloo
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square)
 
 Helm chart for installing microservices as gloo enabled VirtualService definitions.
 

--- a/charts/dvpe-deployment-gloo/README.md
+++ b/charts/dvpe-deployment-gloo/README.md
@@ -248,6 +248,7 @@ The following table lists the configurable parameters of the chart and its defau
 | gloo.virtualservice.spec.virtualHost.cors.allowHeaders | list | `["origin"]` | Specifies the content for the `access-control-allow-headers` header. In general this should not be changed. |
 | gloo.virtualservice.spec.virtualHost.cors.allowMethods | list | `["GET","POST","PUT","DELETE"]` | Specifies the HTTP methods to allow CORS for. |
 | gloo.virtualservice.spec.virtualHost.cors.allowOrigin | string | `nil` | Specifies the URLs of origins to allow CORS for. Origin URLs have to contain scheme, domain and port (if none-standard port is used). |
+| gloo.virtualservice.spec.virtualHost.cors.allowSubdomain | string | `nil` | Specifies the sub domains of origins to allow CORS for. The sub somain has to be given as URL containing scheme, sub domain and port (if none-standard port is used) - e.g. https://bmwgroup.net:8443. |
 | gloo.virtualservice.spec.virtualHost.cors.exposeHeaders | list | `["origin"]` | Specifies the content for the `access-control-expose-headers` header. In general this should not be changed. |
 | gloo.virtualservice.spec.virtualHost.cors.maxAge | string | `"1d"` | Specifies the content for the `access-control-max-age` header. In general this should not be changed. |
 | gloo.virtualservice.spec.virtualHost.domains | string | `nil` | `DNS domain name` this service will be published to. |

--- a/charts/dvpe-deployment-gloo/templates/gloo_virtualservice.yaml
+++ b/charts/dvpe-deployment-gloo/templates/gloo_virtualservice.yaml
@@ -19,7 +19,7 @@ spec:
   virtualHost:
     domains:
       - {{ .Values.gloo.virtualservice.spec.virtualHost.domains }}
-    {{- if .Values.gloo.virtualservice.spec.virtualHost.cors.allowOrigin }}
+    {{- if or .Values.gloo.virtualservice.spec.virtualHost.cors.allowOrigin .Values.gloo.virtualservice.spec.virtualHost.cors.allowSubdomain }}
     options:
       cors:
         allowCredentials: true
@@ -36,6 +36,9 @@ spec:
           - {{ . | quote }}
           {{- end }}
         allowOriginRegex:
+          {{- range .Values.gloo.virtualservice.spec.virtualHost.cors.allowSubdomain }}
+          - {{ . | replace "." "[.]" | replace "://" "://[a-zA-Z0-9.-]+[.]" | quote }}
+          {{- end }}
         exposeHeaders:
           {{- range .Values.gloo.virtualservice.spec.virtualHost.cors.exposeHeaders }}
           - {{ . }}

--- a/charts/dvpe-deployment-gloo/templates/gloo_virtualservice.yaml
+++ b/charts/dvpe-deployment-gloo/templates/gloo_virtualservice.yaml
@@ -37,7 +37,7 @@ spec:
           {{- end }}
         allowOriginRegex:
           {{- range .Values.gloo.virtualservice.spec.virtualHost.cors.allowSubdomain }}
-          - {{ . | replace "." "[.]" | replace "://" "://[a-zA-Z0-9.-]+[.]" | quote }}
+          - {{ . | replace "." "[.]" | replace "://" "://([a-zA-Z0-9]+[.-])*[a-zA-Z0-9]+[.]" | quote }}
           {{- end }}
         exposeHeaders:
           {{- range .Values.gloo.virtualservice.spec.virtualHost.cors.exposeHeaders }}

--- a/charts/dvpe-deployment-gloo/values.yaml
+++ b/charts/dvpe-deployment-gloo/values.yaml
@@ -135,6 +135,8 @@ gloo:
         cors:
           # gloo.virtualservice.spec.virtualHost.cors.allowOrigin -- Specifies the URLs of origins to allow CORS for. Origin URLs have to contain scheme, domain and port (if none-standard port is used).
           allowOrigin:
+          # gloo.virtualservice.spec.virtualHost.cors.allowSubdomain -- Specifies the sub domains of origins to allow CORS for. The sub somain has to be given as URL containing scheme, sub domain and port (if none-standard port is used) - e.g. https://bmwgroup.net:8443.
+          allowSubdomain:
           # gloo.virtualservice.spec.virtualHost.cors.allowMethods -- Specifies the HTTP methods to allow CORS for.
           allowMethods:
             - GET


### PR DESCRIPTION
Extended CORS configuration support by adding  `gloo.virtualservice.spec.virtualHost.cors.allowSubdomain` value.