### PR TITLE
Cluster issuers - hotfix 2

### DIFF
--- a/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
+++ b/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2]
+### Fixed
+* Cluster issuer secret source parameterized (`issuercontroller.externalsecrets.clusterIssuer`)
+
+### Deprecated
+* `issuercontroller.externalsecrets.name` - rename to `issuercontroller.externalsecrets.dockerCredentials`
+
 ## [0.2.1]
 ### Fixed
 * Tag of the issuer

--- a/charts/dvpe-certificate-issuer-controller/Chart.yaml
+++ b/charts/dvpe-certificate-issuer-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.1
 description: Helm chart for deploying a custom certificate issuer controller. The certificate issuer controller is a [cert-manager](https://cert-manager.io/docs/) resource managing certificate requests in a private PKI.
 name: dvpe-certificate-issuer-controller
-version: 0.2.1
+version: 0.2.2
 keywords:
   - automation
   - gitops

--- a/charts/dvpe-certificate-issuer-controller/README.md
+++ b/charts/dvpe-certificate-issuer-controller/README.md
@@ -1,6 +1,6 @@
 # dvpe-certificate-issuer-controller
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
 
 Helm chart for deploying a custom certificate issuer controller. The certificate issuer controller is a [cert-manager](https://cert-manager.io/docs/) resource managing certificate requests in a private PKI.
 
@@ -32,8 +32,10 @@ s
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| issuercontroller | object | `{"externalsecrets":{"name":null},"plane":{"name":"wadtfy-cert-issuer-controller-system"},"spec":{"image":{"name":"wadtfy-issuer","pullPolicy":"IfNotPresent","repository":null,"tag":"v1.2.0"}}}` | -----------------------------# |
-| issuercontroller.externalsecrets.name | string | `nil` | The name of the external secret key containing the docker credentials for this deployment |
+| issuercontroller | object | `{"externalsecrets":{"clusterIssuer":null,"dockerCredentials":null,"name":null},"plane":{"name":"wadtfy-cert-issuer-controller-system"},"spec":{"image":{"name":"wadtfy-issuer","pullPolicy":"IfNotPresent","repository":null,"tag":"v1.2.0"}}}` | -----------------------------# |
+| issuercontroller.externalsecrets.clusterIssuer | string | `nil` | The name of the external secret for the cluster certificate issuer |
+| issuercontroller.externalsecrets.dockerCredentials | string | `nil` | The name of the external secret key containing the docker credentials for this deployment (earlier: `issuercontroller.externalsecrets.name`) |
+| issuercontroller.externalsecrets.name | string | `nil` | DEPRECATED; rename to `issuercontroller.externalsecrets.dockerCredentials` |
 | issuercontroller.plane.name | string | `"wadtfy-cert-issuer-controller-system"` | Name of the Controller Plane |
 | issuercontroller.spec.image | object | `{"name":"wadtfy-issuer","pullPolicy":"IfNotPresent","repository":null,"tag":"v1.2.0"}` | Name of issuer-controller deployment image |
 | issuercontroller.spec.image.name | string | `"wadtfy-issuer"` | The image name to use. |

--- a/charts/dvpe-certificate-issuer-controller/templates/externalsecret.yaml
+++ b/charts/dvpe-certificate-issuer-controller/templates/externalsecret.yaml
@@ -1,21 +1,25 @@
+{{- $namespace := .Release.Namespace }}
+
+{{- with .Values.issuercontroller.externalsecrets }}
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{ .Values.issuercontroller.externalsecrets.name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ default .name .dockerCredentials }}
+  namespace: {{ $namespace }}
 spec:
   backendType: secretsManager
   template:
     type: kubernetes.io/dockerconfigjson
   dataFrom:
-    - {{ .Values.issuercontroller.externalsecrets.name }}
+    - {{ default .name .dockerCredentials }}
 ---
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: wadtfy-cluster-issuer-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $namespace }}
 spec:
   backendType: secretsManager
   dataFrom:
-    - lab.ops.clcm
+    - {{ .clusterIssuer }}
+{{- end}}

--- a/charts/dvpe-certificate-issuer-controller/values.schema.json
+++ b/charts/dvpe-certificate-issuer-controller/values.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "issuercontroller": {
+      "type": "object",
+      "properties": {
+        "externalsecrets": {
+          "anyOf": [
+            {
+              "properties": {
+                "dockerCredentials": {
+                  "type": "string"
+                },
+                "clusterIssuer": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dockerCredentials",
+                "clusterIssuer"
+              ]
+            },
+            {
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "clusterIssuer": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "clusterIssuer"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "externalsecrets"
+      ]
+    }
+  },
+  "required": [
+    "issuercontroller"
+  ]
+}

--- a/charts/dvpe-certificate-issuer-controller/values.yaml
+++ b/charts/dvpe-certificate-issuer-controller/values.yaml
@@ -19,5 +19,9 @@ issuercontroller:
       # issuercontroller.spec.image.pullPolicy -- The default rule for downloading images.
       pullPolicy: IfNotPresent
   externalsecrets:
-    # issuercontroller.externalsecrets.name -- The name of the external secret key containing the docker credentials for this deployment
+    # issuercontroller.externalsecrets.name -- DEPRECATED; rename to `issuercontroller.externalsecrets.dockerCredentials`
     name:
+    # issuercontroller.externalsecrets.dockerCredentials -- The name of the external secret key containing the docker credentials for this deployment (earlier: `issuercontroller.externalsecrets.name`)
+    dockerCredentials:
+    # issuercontroller.externalsecrets.clusterIssuer -- The name of the external secret for the cluster certificate issuer
+    clusterIssuer:


### PR DESCRIPTION
### Fixed
* Cluster issuer secret source parameterized (`issuercontroller.externalsecrets.clusterIssuer`)

### Deprecated
* `issuercontroller.externalsecrets.name` - rename to `issuercontroller.externalsecrets.dockerCredentials`