### PR TITLE
change secret of cluster-issuer to external-secrets-operator

### DIFF
--- a/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
+++ b/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0]
+## [1.0.0]
 ### Changed
 * Cluster issuer secret uses External Secrets Operator (`issuercontroller.externalsecrets.clusterIssuer`)
+* Cluster needs to be configured to use the [External Secrets Operator](https://external-secrets.io/v0.7.2/) 
 
 ## [0.2.3]
 ### Fixed

--- a/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
+++ b/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.3.0]
-### Fixed
+### Changed
 * Cluster issuer secret uses External Secrets Operator (`issuercontroller.externalsecrets.clusterIssuer`)
 
 ## [0.2.3]

--- a/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
+++ b/charts/dvpe-certificate-issuer-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0]
+### Fixed
+* Cluster issuer secret uses External Secrets Operator (`issuercontroller.externalsecrets.clusterIssuer`)
+
 ## [0.2.3]
 ### Fixed
 * Cluster issuer secret source parameterized (`issuercontroller.externalsecrets.clusterIssuer`)

--- a/charts/dvpe-certificate-issuer-controller/Chart.yaml
+++ b/charts/dvpe-certificate-issuer-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.1
 description: Helm chart for deploying a custom certificate issuer controller. The certificate issuer controller is a [cert-manager](https://cert-manager.io/docs/) resource managing certificate requests in a private PKI.
 name: dvpe-certificate-issuer-controller
-version: 0.2.3
+version: 0.3.0
 keywords:
   - automation
   - gitops
@@ -10,4 +10,4 @@ keywords:
 maintainers:
   - name: mithie
   - name: herrLierb
-  - name: christodo
+  - name: crimbler2

--- a/charts/dvpe-certificate-issuer-controller/Chart.yaml
+++ b/charts/dvpe-certificate-issuer-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.1
 description: Helm chart for deploying a custom certificate issuer controller. The certificate issuer controller is a [cert-manager](https://cert-manager.io/docs/) resource managing certificate requests in a private PKI.
 name: dvpe-certificate-issuer-controller
-version: 0.3.0
+version: 1.0.0
 keywords:
   - automation
   - gitops

--- a/charts/dvpe-certificate-issuer-controller/README.md
+++ b/charts/dvpe-certificate-issuer-controller/README.md
@@ -1,6 +1,6 @@
 # dvpe-certificate-issuer-controller
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
 
 Helm chart for deploying a custom certificate issuer controller. The certificate issuer controller is a [cert-manager](https://cert-manager.io/docs/) resource managing certificate requests in a private PKI.
 

--- a/charts/dvpe-certificate-issuer-controller/templates/externalsecret.yaml
+++ b/charts/dvpe-certificate-issuer-controller/templates/externalsecret.yaml
@@ -1,25 +1,37 @@
 {{- $namespace := .Release.Namespace }}
 
 {{- with .Values.issuercontroller.externalsecrets }}
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ default .name .dockerCredentials }}
   namespace: {{ $namespace }}
 spec:
-  backendType: secretsManager
-  template:
-    type: kubernetes.io/dockerconfigjson
+  secretStoreRef:
+    kind: SecretStore
+    name: external-secret-store-{{ $namespace }}
+  target:
+    template:
+      type: kubernetes.io/dockerconfigjson
+    name: {{ default .name .dockerCredentials }}
+    creationPolicy: Owner
   dataFrom:
-    - {{ default .name .dockerCredentials }}
+    - extract:
+        key: "{{ default .name .dockerCredentials }}"
 ---
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: wadtfy-cluster-issuer-secret
   namespace: {{ $namespace }}
 spec:
-  backendType: secretsManager
+  secretStoreRef:
+    kind: SecretStore
+    name: external-secret-store-{{ $namespace }}
+  target:
+    name: {{ .clusterIssuer }}
+    creationPolicy: Owner
   dataFrom:
-    - {{ .clusterIssuer }}
+    - extract:
+        key: "{{ .clusterIssuer }}"
 {{- end}}


### PR DESCRIPTION
This Pull Request updates the external secrets of the cluster-issuer-helm-chart to use the new external secrets operator.
It is tested and works.